### PR TITLE
マイプロフィール編集エリアを作成/エラーメッセージ・メッセージコンポーネント作成 #8

### DIFF
--- a/app/components/ui/CError.vue
+++ b/app/components/ui/CError.vue
@@ -1,0 +1,37 @@
+<template>
+    <section v-if="errors && errors.length > 0" class="c-error c-form-item">
+        <ul class="errors">
+            <li v-for="(error, index) in errors" :key="index" class="error">
+                {{ error.message }}
+                <em v-if="error.code > 0">({{ error.code }})</em>
+            </li>
+        </ul>
+    </section>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+import { ApplicationError } from '~/types/error'
+@Component
+export default class CError extends Vue {
+    @Prop({ type: Array, default: [] }) errors?: Array<ApplicationError>
+}
+</script>
+<style lang="stylus">
+.c-error
+    padding: 16px
+    font-size: 14px
+    line-height: 170%
+    border-radius: 4px
+    color: $danger-color
+    background-color: $danger-bg-color
+    border: 1px solid $danger-border-color
+    .errors
+        @extend .zero-space
+        list-style: none
+        .error
+            @extend .zero-space
+            font-weight: bold
+            em
+                font-style: normal
+                font-size: 80%
+</style>

--- a/app/components/user/CUserListItem.vue
+++ b/app/components/user/CUserListItem.vue
@@ -1,5 +1,4 @@
 <template>
-    <!-- <li v-if="user" class="c-user-list-item" @click="selectUser"> -->
     <li v-if="user" class="c-user-list-item">
         <ns-column center>
             <div class="c-user-list-item-photo">

--- a/app/plugins/mixins.ts
+++ b/app/plugins/mixins.ts
@@ -12,6 +12,7 @@ import CLabel from '~/components/ui/CLabel.vue'
 import CLabeledItem from '~/components/ui/CLabeledItem.vue'
 import CDropdown from '~/components/ui/CDropdown.vue'
 import CMessage from '~/components/ui/CMessage.vue'
+import CError from '~/components/ui/CError.vue'
 
 Vue.mixin({
     components: {
@@ -26,7 +27,8 @@ Vue.mixin({
         CLabel,
         CLabeledItem,
         CDropdown,
-        CMessage
+        CMessage,
+        CError
     }
 })
 

--- a/app/store/user.ts
+++ b/app/store/user.ts
@@ -59,7 +59,7 @@ export const actions: ActionTree<State, RootState> = {
     async sync(context) {
         // 差し替え用リストを定義
         const newList: Array<ILoginUser> = []
-    // ユーザーリスト取得通信メソッド
+        // ユーザーリスト取得通信メソッド
         const loadUsers = async (page: number = 1) => {
             try {
                 const result = await this.$axios.$get('/api/users')

--- a/app/types/error.ts
+++ b/app/types/error.ts
@@ -1,0 +1,21 @@
+export interface IApplicationError {
+    name: string
+    statusCode: number
+    message: string
+}
+export class ApplicationError implements Error, IApplicationError {
+    public name: string = 'ApplicationError'
+    public statusCode: number = 500
+    constructor(public message: string, public code: number = 0) {}
+    toString() {
+        return `${this.name} ${this.message} (${this.code})`
+    }
+}
+export class BadRequest extends ApplicationError {
+    public name: string = 'BadRequest'
+    public statusCode: number = 400
+}
+export class InternalServerError extends ApplicationError {
+    public name: string = 'InternalServerError'
+    public statusCode: number = 500
+}


### PR DESCRIPTION
- マイページにてマイプロフィールを編集できるエリアを作成

- バリデーションエラーなどエラーを可視化するため、エラーメッセージ表示コンポーネント作成。

- 更新に成功した時も同様に可視化するため、メッセージ表示コンポーネント作成。