### PR TITLE
ユーザー詳細画面の作成 issue#10

### DIFF
--- a/app/components/layout/NsPanel.vue
+++ b/app/components/layout/NsPanel.vue
@@ -1,0 +1,126 @@
+<template>
+    <section class="panel-layout" :class="getClass">
+        <h3 v-if="title && title.length > 0" class="panel-title">{{ title }}</h3>
+        <div class="panel-content">
+            <slot />
+        </div>
+    </section>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+@Component({
+    name: 'ns-panel'
+})
+export default class NsPanel extends Vue {
+    // パネルタイトル
+    @Prop({ type: String, default: null }) title?: string
+    // カラーリング
+    @Prop(Boolean) primary!: boolean
+    @Prop(Boolean) secondary!: boolean
+    @Prop(Boolean) light!: boolean
+    @Prop(Boolean) dark!: boolean
+    @Prop(Boolean) info!: boolean
+    @Prop(Boolean) success!: boolean
+    @Prop(Boolean) warning!: boolean
+    @Prop(Boolean) danger!: boolean
+    get getClass() {
+        return {
+            'title-disabled': !(this.title && this.title.length > 0),
+            primary: this.primary,
+            secondary: this.secondary,
+            light: this.light,
+            dark: this.dark,
+            info: this.info,
+            success: this.success,
+            warning: this.warning,
+            danger: this.danger
+        }
+    }
+}
+</script>
+<style lang="stylus">
+.panel-layout
+    position: relative
+    .panel-title
+        position: relative
+        padding: $panel-title-padding
+        font-size: $font-medium
+        font-weight: 400
+        color: $secondary-color
+        background-color: $secondary-bg-color
+        border: 1px solid $secondary-border-color
+        border-bottom: 0
+        border-top-left-radius: $panel-border-radius
+        border-top-right-radius: $panel-border-radius
+    .panel-content
+        padding: $panel-content-padding
+        border: 1px solid $secondary-border-color
+        border-top: 0
+        border-bottom-left-radius: $panel-border-radius
+        border-bottom-right-radius: $panel-border-radius
+        > *
+            margin-bottom: $panel-content-margin-bottom
+            &:last-child
+                margin-bottom: 0
+    &.title-disabled
+        .panel-content
+            border-top: 1px solid $secondary-border-color
+            border-top-left-radius: $panel-border-radius
+            border-top-right-radius: $panel-border-radius
+    &.primary
+        .panel-title
+            color: $primary-color
+            background-color: $primary-bg-color
+            border-color: $primary-border-color
+        .panel-content
+            border-color: $primary-border-color
+    &.secondary
+        .panel-title
+            color: $secondary-color
+            background-color: $secondary-bg-color
+            border-color: $secondary-border-color
+        .panel-content
+            border-color: $secondary-border-color
+    &.light
+        .panel-title
+            color: $light-color
+            background-color: $light-bg-color
+            border-color: $light-border-color
+        .panel-content
+            border-color: $light-border-color
+    &.dark
+        .panel-title
+            color: $dark-color
+            background-color: $dark-bg-color
+            border-color: $dark-border-color
+        .panel-content
+            border-color: $dark-border-color
+    &.info
+        .panel-title
+            color: $info-color
+            background-color: $info-bg-color
+            border-color: $info-border-color
+        .panel-content
+            border-color: $info-border-color
+    &.success
+        .panel-title
+            color: $success-color
+            background-color: $success-bg-color
+            border-color: $success-border-color
+        .panel-content
+            border-color: $success-border-color
+    &.warning
+        .panel-title
+            color: $warning-color
+            background-color: $warning-bg-color
+            border-color: $warning-border-color
+        .panel-content
+            border-color: $warning-border-color
+    &.danger
+        .panel-title
+            color: $danger-color
+            background-color: $danger-bg-color
+            border-color: $danger-border-color
+        .panel-content
+            border-color: $danger-border-color
+</style>

--- a/app/components/user/CUserListItem.vue
+++ b/app/components/user/CUserListItem.vue
@@ -4,6 +4,7 @@
             <div class="c-user-list-item-photo">
                 <img v-if="user.image_url" :src="user.image_url" />
                 <img v-else src="/img/user-icon.png" />
+                <nuxt-link :to="`/user/${user.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
             </div>
             <table class="c-user-list-item-data table no-border">
                 <tbody>
@@ -65,10 +66,15 @@ export default class CUserListItem extends Vue {
     .c-user-list-item-photo
         flex: 0 0 200px !important
         height: 200px
+        position: relative
         background-color: #eee
         margin-right: 8px
         img
             width: 100%
+        .button
+            position: absolute
+            right: 8px
+            bottom: 8px
     .c-user-list-item-data
         flex: 1 1 auto !important
         tr:first-child

--- a/app/components/user/detail/CUserDetailInfo.vue
+++ b/app/components/user/detail/CUserDetailInfo.vue
@@ -1,14 +1,58 @@
 <template>
-    <!-- <ns-panel v-if="user" class="c-user-detail-info"> -->
-    <ns-panel class="c-user-detail-info">
-        ユーザー概要表示を作成TODO
+    <ns-panel v-if="user" class="c-user-detail-info">
+        <table class="table no-border">
+            <tbody>
+                <tr>
+                    <td style="width:120px">名前</td>
+                    <td>{{ user.name }}</td>
+                </tr>
+                <tr v-if="user.age">
+                    <td>年齢</td>
+                    <td>{{ user.age }}代</td>
+                </tr>
+                <tr v-if="user.gender">
+                    <td>性別</td>
+                    <td>{{ user.gender | genderFormat}}</td>
+                </tr>
+                <tr v-if="user.favorite_music_age">
+                    <td>好きな音楽の年代</td>
+                    <td>{{ user.favorite_music_age }}年代</td>
+                </tr>
+                <tr v-if="user.favorite_artist">
+                    <td>好きなアーティスト</td>
+                    <td>{{ user.favorite_artist }}</td>
+                </tr>
+                <tr v-if="user.comment">
+                    <td>コメント</td>
+                    <td>{{ user.comment }}</td>
+                </tr>
+            </tbody>
+        </table>
     </ns-panel>
 </template>
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
-@Component({})
-export default class CUserDetailInfo extends Vue {}
+import { ILoginUser } from '~/types/user'
+@Component({
+    filters: {
+        genderFormat: (gender) => {
+            if (gender === 1) {
+                return '男性'
+            } else if (gender === 2) {
+                return '女性'
+            } else {
+                return '-'
+            }
+        }
+    }
+})
+export default class CUserDetailInfo extends Vue {
+    @Prop(Object) user!: ILoginUser
+}
 </script>
 
 <style lang="stylus">
+.c-user-detail-info
+    .table
+        margin-bottom: 16px
 </style>

--- a/app/components/user/detail/CUserDetailInfo.vue
+++ b/app/components/user/detail/CUserDetailInfo.vue
@@ -1,0 +1,14 @@
+<template>
+    <!-- <ns-panel v-if="user" class="c-user-detail-info"> -->
+    <ns-panel class="c-user-detail-info">
+        ユーザー概要表示を作成TODO
+    </ns-panel>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+@Component({})
+export default class CUserDetailInfo extends Vue {}
+</script>
+
+<style lang="stylus">
+</style>

--- a/app/components/user/detail/CUserDetailPhoto.vue
+++ b/app/components/user/detail/CUserDetailPhoto.vue
@@ -1,15 +1,41 @@
 <template>
-    <div class="c-user-detail-photo">
-    <!-- <div v-if="user" class="c-user-detail-photo"> -->
+    <div v-if="user" class="c-user-detail-photo">
         <div class="user-photo">
-            アイコンを表示TODO
+            <img v-if="user.image_url" :src="user.image_url" />
+            <img v-else src="/img/user-icon.png" />
         </div>
     </div>
 </template>
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
+import { ILoginUser } from '~/types/user'
 @Component
-export default class CUserDetailPhoto extends Vue {}
+export default class CUserDetailPhoto extends Vue {
+    // ユーザー情報
+    @Prop(Object) user!: ILoginUser
+}
 </script>
 
-<style lang="stylus"></style>
+<style lang="stylus">
+.c-user-photo
+    position: relative
+    width: 100%
+    margin-bottom: 16px
+    &:before
+        content: ''
+        display: block
+        padding-top: 100%
+    .user-photo
+        position: absolute
+        width: 100%
+        height: 100%
+        left: 0
+        top: 0
+        right: 0
+        bottom: 0
+        background-color: $light-bg-color
+        border-radius: 4px
+        img
+            width: 100%
+            border-radius: 4px
+</style>

--- a/app/components/user/detail/CUserDetailPhoto.vue
+++ b/app/components/user/detail/CUserDetailPhoto.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="c-user-detail-photo">
+    <!-- <div v-if="user" class="c-user-detail-photo"> -->
+        <div class="user-photo">
+            アイコンを表示TODO
+        </div>
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+@Component
+export default class CUserDetailPhoto extends Vue {}
+</script>
+
+<style lang="stylus"></style>

--- a/app/pages/user/_id/index.vue
+++ b/app/pages/user/_id/index.vue
@@ -1,0 +1,79 @@
+<template>
+    <ns-page class="page-user-detail">
+        <!-- ヘッダ -->
+        <c-message light style="margin-bottom: 16px" class="page-heading">
+            <h1>{{ user.name }}</h1>
+        </c-message>
+        <!-- メインコンテンツ -->
+        <ns-column v-if="user" :column="2">
+            <!-- ユーザー情報 -->
+            <div class="user-summary">
+                <!-- トップ画像 -->
+                <c-user-detail-photo :user="user" />
+                <!-- ユーザー情報 -->
+                <c-user-detail-info :user="user" />
+                <!-- ボタンエリア -->
+                <ns-panel class="button-area">
+                    ここにボタンを作成
+                </ns-panel>
+            </div>
+            <!-- ユーザー詳細 -->
+            <div class="user-detail">
+                ここに投稿している曲などを表示
+            </div>
+        </ns-column>
+    </ns-page>
+</template>
+<script lang="ts">
+import _ from 'lodash'
+import { Component, Vue } from 'vue-property-decorator'
+import { ILoginUser } from '~/types/user'
+import CUserDetailPhoto from '~/components/user/detail/CUserDetailPhoto.vue'
+import CUserDetailInfo from '~/components/user/detail/CUserDetailInfo.vue'
+@Component({
+    head: {
+        titleTemplate: 'ユーザー詳細 | %s'
+    },
+    components: {
+        CUserDetailPhoto,
+        CUserDetailInfo,
+    }
+})
+export default class PageUserDetail extends Vue {
+    // ユーザー情報
+    user: ILoginUser = ""
+    // 再読み込み
+    async loadUser() {
+        const user = await this.$axios.$get(`/api/user/${this.$route.params.id}`)
+        this.user = user
+    }
+    mounted() {
+        this.loadUser()
+    } 
+}
+</script>
+<style lang="stylus">
+.page-user-detail
+    .page-heading
+        display: flex
+        justify-content: space-between
+        h1
+            font-size: 18px
+            font-weight: bold
+            color: #333
+        .tags
+            text-align: right
+            .tag
+                margin-left: 8px
+    .user-summary
+        flex: 0 0 480px !important
+    .user-detail
+        flex: 1 1 auto !important
+        .heading
+            position: relative
+            border-bottom: 1px solid $light-border-color
+            .buttons
+                position: absolute
+                right: 0
+                top: 0
+</style>

--- a/app/plugins/mixins.ts
+++ b/app/plugins/mixins.ts
@@ -4,6 +4,7 @@ import NsPage from '~/components/layout/NsPage.vue'
 import NsForm from '~/components/layout/NsForm.vue'
 import NsColumn from '~/components/layout/NsColumn.vue'
 import NsModal from '~/components/layout/NsModal.vue'
+import NsPanel from '~/components/layout/NsPanel.vue'
 
 // components/ui
 import CButton from '~/components/ui/CButton.vue'
@@ -21,6 +22,7 @@ Vue.mixin({
         NsForm,
         NsColumn,
         NsModal,
+        NsPanel,
         // ui
         CButton,
         CTextInput,


### PR DESCRIPTION
ユーザー詳細を表示する画面を作成。

- ユーザー一覧画面のユーザーそれぞれのアイコンにユーザー詳細画面へのボタンリンクを追加。

- ユーザー詳細画面には、ユーザーアイコンとユーザー概要を作成。

- ボタンエリアには後で、フォローボタンを追加する。

- 画面の右側にはそのユーザーの投稿した曲やその他詳細を表示する予定。