### PR TITLE
曲一覧画面で曲を選択すると曲情報および投稿者情報が右側に表示 issue#14

### DIFF
--- a/app/assets/style/app.styl
+++ b/app/assets/style/app.styl
@@ -154,12 +154,16 @@ a
             &:after
                 content: ''
 .tag
-    padding: 4px 8px
+    padding: 3px 6px
     border-radius: 2px
-    font-size: 11px
+    font-size: 9px
     color: #fff
-    background-color: #d66
+    background-color: #ddd
     border-radius: 10px
+    &.video
+        background-color: #d66
+    &.description
+        background-color: $primary-color
 .badge
     position: absolute !important
     right: -8px

--- a/app/components/layout/NsCard.vue
+++ b/app/components/layout/NsCard.vue
@@ -1,0 +1,128 @@
+<template>
+    <section class="card-layout" :class="getClass">
+        <h3 v-if="title && title.length > 0" class="card-title">{{ title }}</h3>
+        <div class="card-content">
+            <slot />
+        </div>
+    </section>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+@Component({
+    name: 'ns-card'
+})
+export default class NsCard extends Vue {
+    // パネルタイトル
+    @Prop({ type: String, default: null }) title?: string
+    // カラーリング
+    @Prop(Boolean) primary!: boolean
+    @Prop(Boolean) secondary!: boolean
+    @Prop(Boolean) light!: boolean
+    @Prop(Boolean) dark!: boolean
+    @Prop(Boolean) info!: boolean
+    @Prop(Boolean) success!: boolean
+    @Prop(Boolean) warning!: boolean
+    @Prop(Boolean) danger!: boolean
+    get getClass() {
+        return {
+            'title-disabled': !(this.title && this.title.length > 0),
+            primary: this.primary,
+            secondary: this.secondary,
+            light: this.light,
+            dark: this.dark,
+            info: this.info,
+            success: this.success,
+            warning: this.warning,
+            danger: this.danger
+        }
+    }
+}
+</script>
+<style lang="stylus">
+.card-layout
+    position: relative
+    .card-title
+        position: relative
+        padding: $card-title-padding
+        font-size: $font-normal
+        font-weight: 400
+        color: $secondary-color
+        background-color: $secondary-bg-color
+        border: 1px solid $secondary-border-color
+        border-bottom: 0
+        border-top-left-radius: $card-border-radius
+        border-top-right-radius: $card-border-radius
+        margin-bottom 0
+    .card-content
+        background-color: #fff
+        padding: $card-content-padding
+        border: 1px solid $secondary-border-color
+        border-top: 0
+        border-bottom-left-radius: $card-border-radius
+        border-bottom-right-radius: $card-border-radius
+        > *
+            margin-bottom: $card-content-margin-bottom
+            &:last-child
+                margin-bottom: 0
+    &.title-disabled
+        .card-content
+            border-top: 1px solid $secondary-border-color
+            border-top-left-radius: $card-border-radius
+            border-top-right-radius: $card-border-radius
+    &.primary
+        .card-title
+            color: $primary-color
+            background-color: $primary-bg-color
+            border-color: $primary-border-color
+        .card-content
+            border-color: $primary-border-color
+    &.secondary
+        .card-title
+            color: $secondary-color
+            background-color: $secondary-bg-color
+            border-color: $secondary-border-color
+        .card-content
+            border-color: $secondary-border-color
+    &.light
+        .card-title
+            color: $light-color
+            background-color: $light-bg-color
+            border-color: $light-border-color
+        .card-content
+            border-color: $light-border-color
+    &.dark
+        .card-title
+            color: $dark-color
+            background-color: $dark-bg-color
+            border-color: $dark-border-color
+        .card-content
+            border-color: $dark-border-color
+    &.info
+        .card-title
+            color: $info-color
+            background-color: $info-bg-color
+            border-color: $info-border-color
+        .card-content
+            border-color: $info-border-color
+    &.success
+        .card-title
+            color: $success-color
+            background-color: $success-bg-color
+            border-color: $success-border-color
+        .card-content
+            border-color: $success-border-color
+    &.warning
+        .card-title
+            color: $warning-color
+            background-color: $warning-bg-color
+            border-color: $warning-border-color
+        .card-content
+            border-color: $warning-border-color
+    &.danger
+        .card-title
+            color: $danger-color
+            background-color: $danger-bg-color
+            border-color: $danger-border-color
+        .card-content
+            border-color: $danger-border-color
+</style>

--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -1,0 +1,54 @@
+<template>
+    <div v-if="song" class="c-song-detail">
+        <ns-card title="曲詳細">
+            <table class="c-song-list-item-data table no-border">
+                <tbody>
+                    <tr>
+                        <th style="width: 100px">曲名</th>
+                        <td>
+                            <p class="item-header">
+                                <strong>{{ song.title }}</strong>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>アーティスト</th>
+                        <td>{{ song.artist_name }}</td>
+                    </tr>
+                    <tr>
+                        <th>曲の年代</th>
+                        <td>{{ song.music_age }}年代</td>
+                    </tr>
+                    <tr v-if="song.description">
+                        <th>曲紹介</th>
+                        <td>{{ song.description }}</td>
+                    </tr>
+                    <tr>
+                        <th>投稿日時</th>
+                        <td>{{ song.created_at }}</td>
+                    </tr>
+                    <tr>
+                        <th>更新日時</th>
+                        <td>{{ song.updated_at }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div v-if="song.video_url">
+                動画をここに表示TODO
+            </div>
+        </ns-card>
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
+import { ISong } from '~/types/song'
+@Component({
+    components: {
+    }
+})
+export default class CSongDetail extends Vue {
+    @Prop(Object) song!: ISong
+}
+</script>
+<style lang="stylus">
+</style>

--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -1,53 +1,41 @@
 <template>
     <div v-if="song" class="c-song-detail">
-        <ns-card title="曲詳細">
-            <table class="c-song-list-item-data table no-border">
-                <tbody>
-                    <tr>
-                        <th style="width: 100px">曲名</th>
-                        <td>
-                            <p class="item-header">
-                                <strong>{{ song.title }}</strong>
-                            </p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>アーティスト</th>
-                        <td>{{ song.artist_name }}</td>
-                    </tr>
-                    <tr>
-                        <th>曲の年代</th>
-                        <td>{{ song.music_age }}年代</td>
-                    </tr>
-                    <tr v-if="song.description">
-                        <th>曲紹介</th>
-                        <td>{{ song.description }}</td>
-                    </tr>
-                    <tr>
-                        <th>投稿日時</th>
-                        <td>{{ song.created_at }}</td>
-                    </tr>
-                    <tr>
-                        <th>更新日時</th>
-                        <td>{{ song.updated_at }}</td>
-                    </tr>
-                </tbody>
-            </table>
-            <div v-if="song.video_url">
-                動画をここに表示TODO
+        <div>
+            <div class="heading">
+                <ul class="tabs">
+                    <li v-for="(tab, index) in tabs" :key="index" class="tab" :class="{ active: selectedTab === tab.key }" @click="selectedTab = tab.key">
+                        {{ tab.label }}
+                    </li>
+                </ul>
             </div>
-        </ns-card>
+            <c-song-detail-info
+                v-if="selectedTab === 0"
+                :song="song"
+                class="tab-content"
+            />
+            <c-song-detail-contributor v-if="selectedTab === 1" :song="song" class="tab-content" />
+        </div>
     </div>
 </template>
 <script lang="ts">
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 import { ISong } from '~/types/song'
+import CSongDetailInfo from '~/components/song/detail/CSongDetailInfo.vue'
+import CSongDetailContributor from '~/components/song/detail/CSongDetailContributor.vue'
 @Component({
     components: {
+        CSongDetailInfo,
+        CSongDetailContributor
     }
 })
 export default class CSongDetail extends Vue {
     @Prop(Object) song!: ISong
+    // タブ
+    selectedTab: number = 0
+    tabs: Array<any> = [
+        { label: '曲情報', key: 0 },
+        { label: '投稿者', key: 1 }
+    ]
 }
 </script>
 <style lang="stylus">

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <li v-if="song" class="c-song-list-item">
+    <li v-if="song" class="c-song-list-item" @click="selectSong">
         <ns-column center>
             <div class="c-song-list-item-photo">
                 <img v-if="song.image_url" :src="song.image_url" />
@@ -8,32 +8,24 @@
             <table class="c-song-list-item-data table no-border">
                 <tbody>
                     <tr>
-                        <th>曲名</th>
+                        <th style="width: 100px">曲名</th>
                         <td>
                             <p class="item-header">
                                 <strong>{{ song.title }}</strong>
                                 <span class="tags">
-                                    <span v-if="song.video_url" class="tag">映像あり</span>
+                                    <span v-if="song.video_url" class="tag video">映像あり</span>
+                                    <span v-if="song.description" class="tag description">曲紹介あり</span>
                                 </span>
                             </p>
                         </td>
                     </tr>
-                    <tr v-if="song.artist_name">
+                    <tr>
                         <th>アーティスト</th>
                         <td>{{ song.artist_name }}</td>
                     </tr>
-                    <tr v-if="song.music_age">
+                    <tr>
                         <th>曲の年代</th>
                         <td>{{ song.music_age }}年代</td>
-                    </tr>
-                    <tr v-if="song.description">
-                        <th>曲紹介</th>
-                        <td>{{ song.description }}</td>
-                    </tr>
-                    <tr>
-                        <th>映像</th>
-                        <td v-if="song.video_url">あり</td>
-                        <td v-else>なし</td>
                     </tr>
                 </tbody>
             </table>
@@ -47,6 +39,9 @@ import { ISong } from '~/types/song'
 @Component({})
 export default class CSongListItem extends Vue {
     @Prop(Object) song!: ISong
+
+    @Emit('c-select')
+    selectSong() {}
 }
 </script>
 
@@ -55,9 +50,11 @@ export default class CSongListItem extends Vue {
     padding: 8px 4px
     border-bottom: 1px solid #ddd
     cursor: pointer
+    &.selected
+        background-color: $highlight-color
     .c-song-list-item-photo
-        flex: 0 0 200px !important
-        height: 200px
+        flex: 0 0 120px !important
+        height: 120px
         position: relative
         background-color: #eee
         margin-right: 8px

--- a/app/components/song/detail/CSongDetailContributor.vue
+++ b/app/components/song/detail/CSongDetailContributor.vue
@@ -1,0 +1,94 @@
+<template>
+    <div v-if="song" class="c-song-detail-contributor">
+        <ns-card>
+            <table class="c-song-contributor-data table no-border">
+                <tbody>
+                    <tr>
+                        <td style="width: 120px">ユーザー名</td>
+                        <td style="width: 120px">
+                            <p class="item-header">
+                                <strong>{{ contributor.name }}</strong>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr v-if="contributor.age">
+                        <td>年齢</td>
+                        <td>{{ contributor.age }}代</td>
+                    </tr>
+                    <tr v-if="contributor.gender">
+                        <td>性別</td>
+                        <td>{{ contributor.gender | genderFormat}}</td>
+                    </tr>
+                    <tr v-if="contributor.favorite_music_age">
+                        <td>好きな音楽の年代</td>
+                        <td>{{ contributor.favorite_music_age }}年代</td>
+                    </tr>
+                    <tr v-if="contributor.favorite_artist">
+                        <td>好きなアーティスト</td>
+                        <td>{{ contributor.favorite_artist }}</td>
+                    </tr>
+                    <tr v-if="contributor.comment">
+                        <td>曲紹介</td>
+                        <td>{{ contributor.comment }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div style="text-align: center">
+                <nuxt-link :to="`/user/${contributor.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
+            </div>
+        </ns-card>
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator'
+import { ISong } from '~/types/song'
+import { ILoginUser } from '~/types/user'
+// import CSongDetailInfo from '~/components/song/detail/CSongDetailInfo.vue'
+// import { Isong, IsongCondition } from '~/types/song'
+@Component({
+    filters: {
+        genderFormat: (gender) => {
+            if (gender === 1) {
+                return '男性'
+            } else if (gender === 2) {
+                return '女性'
+            } else {
+                return '-'
+            }
+        }
+    }
+})
+export default class CsongDetailContributor extends Vue {
+    @Prop(Object) song!: ISong | null
+    contributor: ILoginUser = ""
+    // 曲一覧を読み込み
+    async loadContributor() {
+        const contributor = await this.$axios.$get(`/api/user/${this.song!.user_id}`)
+        // const contributor = await this.$axios.$get('/api/user/5')
+        this.contributor = contributor
+        console.log(contributor)
+    }
+    mounted () {
+        if(this.$store.getters['user/isGuest']) {
+            this.$router.replace('/user/signin')
+        }
+        this.loadContributor()
+    }
+    @Watch('song')
+    songChanged() {
+        this.loadContributor()
+    }
+}
+</script>
+<style lang="stylus">
+.c-song-detail-info
+    .card-layout
+        margin-bottom: 16px
+    .condition
+        td span
+            &:after
+                content: ','
+                padding-right: 8px
+            &:last-child:after
+                content: ''
+</style>

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -1,0 +1,77 @@
+<template>
+    <div v-if="song" class="c-song-detail-info">
+        <ns-card>
+            <table class="c-song-list-item-data table no-border">
+                <tbody>
+                    <tr>
+                        <td style="width: 120px">曲名</td>
+                        <td style-="width: 120px">
+                            <p class="item-header">
+                                <strong>{{ song.title }}</strong>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>アーティスト</td>
+                        <td>{{ song.artist_name }}</td>
+                    </tr>
+                    <tr>
+                        <td>曲の年代</td>
+                        <td>{{ song.music_age }}年代</td>
+                    </tr>
+                    <tr v-if="song.description">
+                        <td>曲紹介</td>
+                        <td>{{ song.description }}</td>
+                    </tr>
+                    <tr>
+                        <td>投稿日時</td>
+                        <td>{{ song.created_at }}</td>
+                    </tr>
+                    <tr>
+                        <td>更新日時</td>
+                        <td>{{ song.updated_at }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <div v-if="song.video_url">
+                動画をここに表示TODO
+            </div>
+        </ns-card>
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
+import { ISong } from '~/types/song'
+// import CSongDetailInfo from '~/components/song/detail/CSongDetailInfo.vue'
+// import { Isong, IsongCondition } from '~/types/song'
+@Component({})
+export default class CsongDetailInfo extends Vue {
+    @Prop(Object) song!: ISong | null
+    // conditionVisible(condition: IsongCondition) {
+    //     if (condition) {
+    //         if (condition.price.length > 0) {
+    //             return true
+    //         }
+    //         if (condition.use.length > 0) {
+    //             return true
+    //         }
+    //         if (condition.area.trim().length > 0) {
+    //             return true
+    //         }
+    //     }
+    //     return false
+    // }
+}
+</script>
+<style lang="stylus">
+.c-song-detail-info
+    .card-layout
+        margin-bottom: 16px
+    .condition
+        td span
+            &:after
+                content: ','
+                padding-right: 8px
+            &:last-child:after
+                content: ''
+</style>

--- a/app/components/user/CUserListItem.vue
+++ b/app/components/user/CUserListItem.vue
@@ -9,7 +9,7 @@
             <table class="c-user-list-item-data table no-border">
                 <tbody>
                     <tr>
-                        <th>名前</th>
+                        <th style="width: 130px">名前</th>
                         <td>
                             <p class="item-header">
                                 <strong>{{ user.name }}</strong>

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -1,43 +1,72 @@
 <template>
     <ns-page class="page-song-index">
-        <ul class="song-list">
-            <li v-if="songs.length > 0">
-                全曲数: {{ songs.length }}曲
-            </li>
-            <li v-else>
-                <c-message warning>曲が見つかりませんでした</c-message>
-            </li>
-            <c-song-list-item v-for="song in songs" :key="song.id" :song="song" />
-        </ul>
+        <ns-column>
+            <ul class="song-list">
+                <li v-if="songs.length > 0">
+                    全曲数: {{ songs.length }}曲
+                </li>
+                <li v-else>
+                    <c-message warning>曲が見つかりませんでした</c-message>
+                </li>
+                <c-song-list-item v-for="song in songs" :key="song.id" :class="{ selected: selectedSong && song.id === selectedSong.id }"
+                    :song="song" @c-select="selectSong(song)" />
+            </ul>
+            <!-- 曲詳細 -->
+            <c-song-detail
+                v-if="selectedSong"
+                class="song-detail"
+                :song="selectedSong"
+            />
+            <div v-else class="song-detail">
+                <c-message warning>曲リストから曲を選択してください</c-message>
+            </div>
+        </ns-column>
     </ns-page>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import CSongListItem from '~/components/song/CSongListItem.vue'
+import CSongDetail from '~/components/song/CSongDetail.vue'
 import { ISong } from '~/types/song'
 @Component({
     head: {
         titleTemplate: '曲一覧 | %s'
     },
     components: {
-        CSongListItem
+        CSongListItem,
+        CSongDetail
     }
 })
 export default class PageSongIndex extends Vue {
     songs: Array<ISong> = []
+    // 選択されている顧客
+    selectedSong: ISong | null = null
+    selectSong(song: ISong | null) {
+        this.selectedSong = song
+    }
     // 曲一覧を読み込み
     async loadSongs() {
         await this.$store.dispatch('song/sync')
         this.songs = await this.$store.getters['song/list']
+        this.selectedSong = this.$store.getters['song/find'](this.selectedSong)
     }
     mounted () {
         if(this.$store.getters['user/isGuest']) {
             this.$router.replace('/user/signin')
         }
         this.loadSongs()
+        console.log(this.selectedSong)
     }
 }
 </script>
 
-<style lang="stylus"></style>
+<style lang="stylus">
+.page-song-index
+    .song-list
+        flex: 0 0 480px !important
+    .song-detail
+        flex: 1 1 auto
+        position: fixed
+        right: 30px
+</style>

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -56,7 +56,6 @@ export default class PageSongIndex extends Vue {
             this.$router.replace('/user/signin')
         }
         this.loadSongs()
-        console.log(this.selectedSong)
     }
 }
 </script>

--- a/app/plugins/mixins.ts
+++ b/app/plugins/mixins.ts
@@ -5,6 +5,7 @@ import NsForm from '~/components/layout/NsForm.vue'
 import NsColumn from '~/components/layout/NsColumn.vue'
 import NsModal from '~/components/layout/NsModal.vue'
 import NsPanel from '~/components/layout/NsPanel.vue'
+import NsCard from '~/components/layout/NsCard.vue'
 
 // components/ui
 import CButton from '~/components/ui/CButton.vue'
@@ -23,6 +24,7 @@ Vue.mixin({
         NsColumn,
         NsModal,
         NsPanel,
+        NsCard,
         // ui
         CButton,
         CTextInput,

--- a/app/store/song.ts
+++ b/app/store/song.ts
@@ -36,4 +36,14 @@ export const getters: GetterTree<State, RootState> = {
     list(state): Array<ISong> {
         return state.list
     },
+    // 指定の曲を取得
+    find: (state) => (song: ISong | null) => {
+        if (song === null) {
+            return null
+        }
+        return state.list.find((it) => it.id === song.id)
+    },
+    findId: (state) => (id: number) => {
+        return state.list.find((it) => it.id === id)
+    },
 }


### PR DESCRIPTION
- 曲情報および投稿者情報はタブの選択で切り替えられる。

- ストアに、選択した顧客の情報を取得する記述を追加。

- タブ「投稿者情報」を選択している時、選択中の曲が変わるたびに投稿者の情報を取得するようにしている。

- コンポーネントNsCard.vueを作成。
