### PR TITLE
モーダルコンポーネントの作成/曲追加・編集の機能作成 #18

### DIFF
--- a/app/assets/style/app.styl
+++ b/app/assets/style/app.styl
@@ -154,16 +154,21 @@ a
             &:after
                 content: ''
 .tag
-    padding: 3px 6px
+    padding: 3px 5px
+    margin-left: 4px
     border-radius: 2px
-    font-size: 9px
+    font-size: 6px
     color: #fff
     background-color: #ddd
-    border-radius: 10px
+    // border-radius: 10px
     &.video
         background-color: #d66
+        border-radius: 10px
     &.description
         background-color: $primary-color
+        border-radius: 10px
+    &.self
+        background-color: $yellow-color
 .badge
     position: absolute !important
     right: -8px

--- a/app/components/layout/MModal.vue
+++ b/app/components/layout/MModal.vue
@@ -56,10 +56,9 @@ export default class MModal extends Vue {
 .m-modal
     z-index 999
     position fixed
-    top 0
+    top 4%
     left 0
     width 100%
-    height 100%
     &-bg
         width: 100vw
         height: 100vh
@@ -72,7 +71,7 @@ export default class MModal extends Vue {
         position: absolute
         top: 50%
         left: 50%
-        transform: translate(-50%, -50%)
+        transform: translate(-50%, 0%)
         z-index: 1000
         background: #fff
         border-radius: 3px
@@ -80,7 +79,6 @@ export default class MModal extends Vue {
         text-align left
         color #333
         overflow: hidden
-        // overflow-y scroll
         padding: 0
         // 下部ボタン
         &-bottom

--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -12,6 +12,7 @@
                 v-if="selectedTab === 0"
                 :song="song"
                 class="tab-content"
+                @edit-handler="editButtonHandler"
             />
             <c-song-detail-contributor v-if="selectedTab === 1" :song="song" class="tab-content" />
         </div>
@@ -20,12 +21,15 @@
 <script lang="ts">
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 import { ISong } from '~/types/song'
+import { newSong } from '~/types/initializer'
 import CSongDetailInfo from '~/components/song/detail/CSongDetailInfo.vue'
 import CSongDetailContributor from '~/components/song/detail/CSongDetailContributor.vue'
+import CSongEdit from '~/components/song/CSongEdit.vue'
 @Component({
     components: {
         CSongDetailInfo,
-        CSongDetailContributor
+        CSongDetailContributor,
+        CSongEdit
     }
 })
 export default class CSongDetail extends Vue {
@@ -36,6 +40,11 @@ export default class CSongDetail extends Vue {
         { label: '曲情報', key: 0 },
         { label: '投稿者', key: 1 }
     ]
+    editModalModel: ISong = newSong()
+    editModalVisible: boolean = false
+    
+    @Emit('c-song-detail-edit')
+    editButtonHandler() {}
 }
 </script>
 <style lang="stylus">

--- a/app/components/song/CSongEdit.vue
+++ b/app/components/song/CSongEdit.vue
@@ -1,0 +1,124 @@
+<template>
+    <m-modal
+        :visible.sync="modalVisible"
+        width="900px"
+        height="80vh"
+        :title="syncModel.id === null ? '新しい曲を登録' : syncModel.title + 'を編集'"
+        :is-button="false"
+    >
+        <m-form v-if="showModal == '1'" title="基本情報" class="c-song-edit-form">
+            <c-error :errors.sync="errors" />
+            <c-labeled-item label="曲名" required>
+                <c-text-input :model.sync="model.title" />
+            </c-labeled-item>
+            <c-labeled-item label="アーティスト名" required>
+                <c-text-input :model.sync="model.artist_name" />
+            </c-labeled-item>
+            <c-labeled-item label="曲の年代" required>
+                <c-dropdown :model.sync="model.music_age"  :items="musicAgeItems" data-value="value" />
+            </c-labeled-item>
+            <div class="button-area">
+                <c-button label="キャンセル" small @c-click="cancelHandler" />
+                <c-button label="次へ" primary small @c-click="nextHandler" />
+            </div>
+        </m-form>
+        <m-form v-else-if="showModal == '2'" title="詳細情報" class="c-song-edit-form">
+            <c-error :errors.sync="errors" />
+            <c-labeled-item label="曲の紹介">
+                <c-text-input :model.sync="model.description" multiline />
+            </c-labeled-item>
+            <c-labeled-item label="YouTubeのURL">
+                https://www.youtube.com/watch?v=
+                <c-text-input :model.sync="model.video_url" />
+            </c-labeled-item>
+            <div class="button-area">
+                <c-button class="button-back" label="戻る" small @c-click="previousHandler" />
+                <c-button class="button-confirm" label="完了" :disabled="saveButtonDisabled" primary small @c-click="saveHandler" />
+            </div>
+        </m-form>
+    </m-modal>
+</template>
+<script lang="ts">
+import { Component, Vue, PropSync, Watch } from 'vue-property-decorator'
+import { ISong } from '~/types/song'
+import { ApplicationError, BadRequest } from '~/types/error'
+// import { useTypeItems, structureTypeItems, zoningTypeItems } from '~/types/initializer'
+@Component
+export default class CSongEdit extends Vue {
+    @PropSync('visible') modalVisible!: boolean
+    @PropSync('model') syncModel!: ISong
+    errors: Array<ApplicationError> = []
+    showModal: number = 1
+    musicAgeItems = [
+        { label: '1970年代', value: '1970' },
+        { label: '1980年代', value: '1980' },
+        { label: '1990年代', value: '1990' },
+        { label: '2000年代', value: '2000' },
+        { label: '2010年代', value: '2010' }
+    ]
+    // 次へボタンが押された
+    async nextHandler() {
+        try {
+            this.errors = []
+            // バリデーション
+            if (this.syncModel.title.length === 0) {
+                this.errors.push(new BadRequest('曲名が入力されていません'))
+            }
+            if (this.syncModel.artist_name.length === 0) {
+                this.errors.push(new BadRequest('アーティスト名が入力されていません'))
+            }
+            if (!this.syncModel.music_age) {
+                this.errors.push(new BadRequest('曲の年代が入力されていません'))
+            }
+            // 次の入力画面へ画面遷移する
+            if (this.errors.length === 0) {
+                this.showModal = 2
+            }
+        } catch (e) {
+            this.errors.push(e)
+        }
+    }
+    // 前へボタンが押された
+    previousHandler() {
+        this.showModal = 1
+    }
+    // キャンセルボタンが押された
+    cancelHandler() {
+        this.modalVisible = false
+        this.showModal = 1
+    }
+    // 完了ボタンが押された
+    saveButtonDisabled: boolean = false
+    async saveHandler() {
+        console.log(this.syncModel)
+        this.saveButtonDisabled = true
+        this.errors = []
+        try {
+            if (this.syncModel.id !== null) {
+                await this.$axios.$put(`/api/song/${this.syncModel.id}`, this.syncModel).catch((e) => {
+                    const { message, code } = e.response.data
+                    throw new ApplicationError(message, code)
+                })
+            } else {
+                await this.$axios.$post('/api/song', this.syncModel).catch((e) => {
+                    const { message, code } = e.response.data
+                    throw new ApplicationError(message, code)
+                })
+            }
+            this.modalVisible = false
+            this.$emit('c-song-edit-finished')
+            this.showModal = 1
+            this.saveButtonDisabled = false
+        } catch (e) {
+            this.errors.push(e)
+            this.saveButtonDisabled = false
+        }
+    }
+}
+</script>
+<style lang="stylus">
+.c-song-edit-form
+    .c-text-input
+        ::placeholder
+            text-align right
+</style>

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -77,6 +77,4 @@ export default class CSongListItem extends Vue {
                     justify-content: space-between
                     .tags
                         text-align: right
-                        // .tag
-                        //     margin-left: 4px
 </style>

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -13,6 +13,7 @@
                             <p class="item-header">
                                 <strong>{{ song.title }}</strong>
                                 <span class="tags">
+                                    <span v-if="song.user_id === $store.getters['user/user'].id" class="tag self">自分の投稿</span>
                                     <span v-if="song.video_url" class="tag video">映像あり</span>
                                     <span v-if="song.description" class="tag description">曲紹介あり</span>
                                 </span>
@@ -76,6 +77,6 @@ export default class CSongListItem extends Vue {
                     justify-content: space-between
                     .tags
                         text-align: right
-                        .tag
-                            margin-left: 8px
+                        // .tag
+                        //     margin-left: 4px
 </style>

--- a/app/components/song/CSongSearch.vue
+++ b/app/components/song/CSongSearch.vue
@@ -1,0 +1,17 @@
+<template>
+    <m-panel class="c-song-search">
+        <p>TODO検索フィルタ作成</p>
+        <c-button small primary label="新規追加" @c-click="addSongHandler" />
+    </m-panel>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Emit } from 'vue-property-decorator'
+@Component({})
+export default class CSongSearch extends Vue {
+    @Emit('add-handler')
+    addSongHandler() {}
+}
+</script>
+
+<style lang="stylus"></style>

--- a/app/components/song/detail/CSongDetailContributor.vue
+++ b/app/components/song/detail/CSongDetailContributor.vue
@@ -8,6 +8,7 @@
                         <td style="width: 120px">
                             <p class="item-header">
                                 <strong>{{ contributor.name }}</strong>
+                                <span v-if="song.user_id === $store.getters['user/user'].id" class="tag self">自分</span>
                             </p>
                         </td>
                     </tr>
@@ -17,7 +18,7 @@
                     </tr>
                     <tr v-if="contributor.gender">
                         <td>性別</td>
-                        <td>{{ contributor.gender | genderFormat}}</td>
+                        <td>{{ contributor.gender | genderFormat }}</td>
                     </tr>
                     <tr v-if="contributor.favorite_music_age">
                         <td>好きな音楽の年代</td>
@@ -34,7 +35,8 @@
                 </tbody>
             </table>
             <div style="text-align: center">
-                <nuxt-link :to="`/user/${contributor.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
+                <nuxt-link v-if="song.user_id === $store.getters['user/user'].id" to="/user/mypage" class="button primary">マイページへ</nuxt-link>
+                <nuxt-link v-else to="`/user/${contributor.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
             </div>
         </m-card>
     </div>

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -37,42 +37,37 @@
             <div v-if="song.video_url">
                 動画をここに表示TODO
             </div>
+            <c-button
+                v-if="song.user_id === $store.getters['user/user'].id"
+                small
+                block
+                label="曲情報を編集"
+                @c-click="editButtonHandler"
+            />
         </m-card>
     </div>
 </template>
 <script lang="ts">
+import _ from 'lodash'
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 import { ISong } from '~/types/song'
-// import CSongDetailInfo from '~/components/song/detail/CSongDetailInfo.vue'
-// import { Isong, IsongCondition } from '~/types/song'
-@Component({})
+import { newSong } from '~/types/initializer'
+import CSongEdit from '~/components/song/CSongEdit.vue'
+@Component({
+    components: {
+        CSongEdit
+    }
+})
 export default class CsongDetailInfo extends Vue {
-    @Prop(Object) song!: ISong | null
-    // conditionVisible(condition: IsongCondition) {
-    //     if (condition) {
-    //         if (condition.price.length > 0) {
-    //             return true
-    //         }
-    //         if (condition.use.length > 0) {
-    //             return true
-    //         }
-    //         if (condition.area.trim().length > 0) {
-    //             return true
-    //         }
-    //     }
-    //     return false
-    // }
+    @Prop(Object) song!: ISong
+    editModalModel: ISong = newSong()
+    editModalVisible: boolean = false
+    @Emit('edit-handler')
+    editButtonHandler() {}
 }
 </script>
 <style lang="stylus">
 .c-song-detail-info
     .card-layout
         margin-bottom: 16px
-    .condition
-        td span
-            &:after
-                content: ','
-                padding-right: 8px
-            &:last-child:after
-                content: ''
 </style>

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -8,6 +8,7 @@
                         <td style-="width: 120px">
                             <p class="item-header">
                                 <strong>{{ song.title }}</strong>
+                                <span v-if="song.user_id === $store.getters['user/user'].id" class="tag self">自分の投稿</span>
                             </p>
                         </td>
                     </tr>

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -1,5 +1,8 @@
 <template>
     <m-page class="page-song-index">
+        <c-song-search
+            @add-handler="addSongHandler"
+        />
         <m-column>
             <ul class="song-list">
                 <li v-if="songs.length > 0">
@@ -16,11 +19,13 @@
                 v-if="selectedSong"
                 class="song-detail"
                 :song="selectedSong"
+                @c-song-detail-edit="editButtonHandler"
             />
             <div v-else class="song-detail">
                 <c-message warning>曲リストから曲を選択してください</c-message>
             </div>
         </m-column>
+        <c-song-edit :visible.sync="songModalVisible" :model.sync="songModalModel" @c-song-edit-finished="songEditFinished" />
     </m-page>
 </template>
 
@@ -28,14 +33,19 @@
 import { Component, Vue } from 'vue-property-decorator'
 import CSongListItem from '~/components/song/CSongListItem.vue'
 import CSongDetail from '~/components/song/CSongDetail.vue'
+import CSongEdit from '~/components/song/CSongEdit.vue'
+import CSongSearch from '~/components/song/CSongSearch.vue'
 import { ISong } from '~/types/song'
+import { newSong } from '~/types/initializer'
 @Component({
     head: {
         titleTemplate: '曲一覧 | %s'
     },
     components: {
         CSongListItem,
-        CSongDetail
+        CSongDetail,
+        CSongEdit,
+        CSongSearch
     }
 })
 export default class PageSongIndex extends Vue {
@@ -44,6 +54,24 @@ export default class PageSongIndex extends Vue {
     selectedSong: ISong | null = null
     selectSong(song: ISong | null) {
         this.selectedSong = song
+    }
+    songModalModel: ISong = newSong()
+    songModalVisible: boolean = false
+    // 曲を追加
+    addSongHandler() {
+        this.songModalModel = newSong()
+        this.songModalVisible = true
+    }
+    // 曲を編集
+    editButtonHandler() {
+        if(this.selectedSong){
+            this.songModalModel = _.cloneDeep(this.selectedSong)
+            this.songModalVisible = true
+        }
+    }
+    // 曲の編集完了後に曲一覧を再読み込み
+    async songEditFinished() {
+        this.loadSongs()
     }
     // 曲一覧を読み込み
     async loadSongs() {

--- a/app/types/initializer.ts
+++ b/app/types/initializer.ts
@@ -1,0 +1,16 @@
+import { ISong } from '~/types/song'
+export function newSong(): ISong {
+    return {
+        id: null,
+        user_id: null,
+        title: '',
+        artist_name: '',
+        music_age: null,
+        description: null,
+        image_url: null,
+        video_url: null,
+        created_at: '',
+        updated_at: '',
+        deleted_at: null
+    }
+}

--- a/app/types/song.d.ts
+++ b/app/types/song.d.ts
@@ -1,9 +1,9 @@
 export interface ISong {
-    id: number
-    user_id: number
+    id: number | null
+    user_id: number | null
     title: string
     artist_name: string
-    music_age: number
+    music_age: number | null
     description: string | null
     image_url: string | null
     video_url: string | null


### PR DESCRIPTION
- モーダルコンポーネントを作成。

- 曲追加と曲編集を兼ねたモーダルを作成し、曲にIDがすでに付いているか否かで追加モーダルか編集モーダルかを分ける条件分岐を記述。

- 曲リストにて、自分の投稿した曲は自分のものだと分かるようにラベルを付与。

- 曲を新規追加するボタンを作成。

- 自分の投稿した曲に関しては、曲編集ボタンを付与。

- 曲を追加・更新したあとは、曲一覧を再読み込み。