### PR TITLE
お気に入り登録・解除ボタンの追加/ISongにis_bookmarkedを追加 issue#23

### DIFF
--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -14,6 +14,8 @@
                 class="tab-content"
                 @edit-handler="editButtonHandler"
                 @delete-handler="deleteButtonHandler"
+                @bookmark-handler="bookmarkButtonHandler"
+                @remove-bookmark-handler="removeBookmarkButtonHandler"
             />
             <c-song-detail-contributor v-if="selectedTab === 1" :song="song" class="tab-content" />
         </div>
@@ -49,6 +51,12 @@ export default class CSongDetail extends Vue {
     
     @Emit('c-song-detail-delete')
     deleteButtonHandler() {}
+
+    @Emit('c-song-detail-bookmark')
+    bookmarkButtonHandler() {}
+
+    @Emit('c-song-detail-remove-bookmark')
+    removeBookmarkButtonHandler() {}
 }
 </script>
 <style lang="stylus">

--- a/app/components/song/detail/CSongDetailContributor.vue
+++ b/app/components/song/detail/CSongDetailContributor.vue
@@ -36,7 +36,7 @@
             </table>
             <div style="text-align: center">
                 <nuxt-link v-if="song.user_id === $store.getters['user/user'].id" to="/user/mypage" class="button primary">マイページへ</nuxt-link>
-                <nuxt-link v-else to="`/user/${contributor.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
+                <nuxt-link v-else :to="`/user/${contributor.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
             </div>
         </m-card>
     </div>
@@ -65,7 +65,6 @@ export default class CsongDetailContributor extends Vue {
     async loadContributor() {
         const contributor = await this.$axios.$get(`/api/user/${this.song!.user_id}`)
         this.contributor = contributor
-        console.log(contributor)
     }
     mounted () {
         if(this.$store.getters['user/isGuest']) {

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -56,7 +56,6 @@
     </div>
 </template>
 <script lang="ts">
-import _ from 'lodash'
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 import { ISong } from '~/types/song'
 import { newSong } from '~/types/initializer'

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -52,6 +52,21 @@
                 label="削除"
                 @c-click="deleteButtonHandler"
             />
+            <c-button
+                v-if="song.user_id !== $store.getters['user/user'].id && !song.is_bookmarked" 
+                small
+                block
+                label="お気に入りに登録する"
+                @c-click="bookmarkButtonHandler"
+            />
+            <c-button
+                v-if="song.user_id !== $store.getters['user/user'].id && song.is_bookmarked"
+                warning
+                small
+                block
+                label="お気に入りから外す"
+                @c-click="removeBookmarkButtonHandler"
+            />
         </m-card>
     </div>
 </template>
@@ -75,6 +90,12 @@ export default class CSongDetailInfo extends Vue {
     
     @Emit('delete-handler')
     deleteButtonHandler() {}
+
+    @Emit('bookmark-handler')
+    bookmarkButtonHandler() {}
+    
+    @Emit('remove-bookmark-handler')
+    removeBookmarkButtonHandler() {}
 }
 </script>
 <style lang="stylus">

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -21,6 +21,8 @@
                 :song="selectedSong"
                 @c-song-detail-edit="editButtonHandler"
                 @c-song-detail-delete="deleteButtonHandler"
+                @c-song-detail-bookmark="bookmarkButtonHandler"
+                @c-song-detail-remove-bookmark="removeBookmarkButtonHandler"
             />
             <div v-else class="song-detail">
                 <c-message warning>曲リストから曲を選択してください</c-message>
@@ -79,6 +81,20 @@ export default class PageSongIndex extends Vue {
                 this.selectedSong = null
                 this.loadSongs()
             }
+        }
+    }
+    // 曲をお気に入り登録する
+    async bookmarkButtonHandler() {
+        if (this.selectedSong) {
+            await this.$axios.$post(`/api/song/${this.selectedSong.id}/bookmark`)
+            this.loadSongs()
+        }
+    }
+    // 曲をお気に入りから外す
+    async removeBookmarkButtonHandler() {
+        if (this.selectedSong) {
+            await this.$axios.$post(`/api/song/${this.selectedSong.id}/removeBookmark`)
+            this.loadSongs()
         }
     }
     // 曲の編集完了後に曲一覧を再読み込み

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script lang="ts">
+import _ from 'lodash'
 import { Component, Vue } from 'vue-property-decorator'
 import CSongListItem from '~/components/song/CSongListItem.vue'
 import CSongDetail from '~/components/song/CSongDetail.vue'

--- a/app/types/initializer.ts
+++ b/app/types/initializer.ts
@@ -11,6 +11,7 @@ export function newSong(): ISong {
         video_url: null,
         created_at: '',
         updated_at: '',
-        deleted_at: null
+        deleted_at: null,
+        is_bookmarked: false
     }
 }

--- a/app/types/song.d.ts
+++ b/app/types/song.d.ts
@@ -10,4 +10,5 @@ export interface ISong {
     created_at: string
     updated_at: string
     deleted_at: string | null
+    is_bookmarked: boolean
 }


### PR DESCRIPTION
- ストアに保存される曲に項目is_bookmarked(真偽値)を追加し、曲をログイン中ユーザー（操作中ユーザー）がお気に入りに登録しているか否かを判断できるように。

曲一覧から曲を選択時、
- 曲がお気に入りに登録されていない場合、お気に入り登録ボタンを表示。

- 曲がお気に入りに登録済みの場合、お気に入りから外すボタンを表示。