### PR TITLE
typeのILoginUserにis_followedを追加・ユーザーをフォロー・アンフォローするボタンを曲一覧の投稿者情報・ユーザー詳細画面に追加 #25

### DIFF
--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -17,7 +17,11 @@
                 @bookmark-handler="bookmarkButtonHandler"
                 @remove-bookmark-handler="removeBookmarkButtonHandler"
             />
-            <c-song-detail-contributor v-if="selectedTab === 1" :song="song" class="tab-content" />
+            <c-song-detail-contributor
+                v-if="selectedTab === 1"
+                :song="song"
+                class="tab-content"
+            />
         </div>
     </div>
 </template>

--- a/app/components/song/CSongEdit.vue
+++ b/app/components/song/CSongEdit.vue
@@ -15,7 +15,7 @@
                 <c-text-input :model.sync="model.artist_name" />
             </c-labeled-item>
             <c-labeled-item label="曲の年代" required>
-                <c-dropdown :model.sync="model.music_age"  :items="musicAgeItems" data-value="value" />
+                <c-dropdown :model.sync="model.music_age" :items="musicAgeItems" data-value="value" />
             </c-labeled-item>
             <div class="button-area">
                 <c-button label="キャンセル" small @c-click="cancelHandler" />
@@ -42,7 +42,6 @@
 import { Component, Vue, PropSync, Watch } from 'vue-property-decorator'
 import { ISong } from '~/types/song'
 import { ApplicationError, BadRequest } from '~/types/error'
-// import { useTypeItems, structureTypeItems, zoningTypeItems } from '~/types/initializer'
 @Component
 export default class CSongEdit extends Vue {
     @PropSync('visible') modalVisible!: boolean
@@ -90,7 +89,6 @@ export default class CSongEdit extends Vue {
     // 完了ボタンが押された
     saveButtonDisabled: boolean = false
     async saveHandler() {
-        console.log(this.syncModel)
         this.saveButtonDisabled = true
         this.errors = []
         try {

--- a/app/components/song/detail/CSongDetailContributor.vue
+++ b/app/components/song/detail/CSongDetailContributor.vue
@@ -34,9 +34,24 @@
                     </tr>
                 </tbody>
             </table>
-            <div style="text-align: center">
+            <div style="text-align: center;">
+                <c-button
+                    v-if="contributor.id !== $store.getters['user/user'].id && !contributor.is_followed" 
+                    small
+                    block
+                    label="フォローする"
+                    @c-click="followHandler"
+                />
+                <c-button
+                    v-if="contributor.id !== $store.getters['user/user'].id && contributor.is_followed" 
+                    small
+                    block
+                    warning
+                    label="フォロー中"
+                    @c-click="unfollowHandler"
+                />
                 <nuxt-link v-if="song.user_id === $store.getters['user/user'].id" to="/user/mypage" class="button primary">マイページへ</nuxt-link>
-                <nuxt-link v-else :to="`/user/${contributor.id}`" class="button primary">ユーザー詳細へ</nuxt-link>
+                <nuxt-link v-else :to="`/user/${contributor.id}`" class="button primary" style= "margin-top: 3px;">ユーザー詳細へ</nuxt-link>
             </div>
         </m-card>
     </div>
@@ -61,17 +76,33 @@ import { ILoginUser } from '~/types/user'
 export default class CsongDetailContributor extends Vue {
     @Prop(Object) song!: ISong | null
     contributor: ILoginUser = ""
-    // 曲一覧を読み込み
+
+    // 投稿者一覧を読み込み
     async loadContributor() {
         const contributor = await this.$axios.$get(`/api/user/${this.song!.user_id}`)
         this.contributor = contributor
+        {{ contributor }}
     }
+
+    // ユーザーをフォローする
+    async followHandler() {
+        await this.$axios.$post(`/api/user/${this.contributor.id}/follow`)
+        this.loadContributor()
+    }
+
+    // ユーザーをフォローを外す
+    async unfollowHandler() {
+        await this.$axios.$post(`/api/user/${this.contributor.id}/unfollow`)
+        this.loadContributor()
+    }
+
     mounted () {
         if(this.$store.getters['user/isGuest']) {
             this.$router.replace('/user/signin')
         }
         this.loadContributor()
     }
+
     @Watch('song')
     songChanged() {
         this.loadContributor()

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -97,6 +97,7 @@ export default class PageSongIndex extends Vue {
             this.loadSongs()
         }
     }
+
     // 曲の編集完了後に曲一覧を再読み込み
     async songEditFinished() {
         this.loadSongs()
@@ -107,6 +108,7 @@ export default class PageSongIndex extends Vue {
         this.songs = await this.$store.getters['song/list']
         this.selectedSong = this.$store.getters['song/find'](this.selectedSong)
     }
+    
     mounted () {
         if(this.$store.getters['user/isGuest']) {
             this.$router.replace('/user/signin')

--- a/app/pages/user/_id/index.vue
+++ b/app/pages/user/_id/index.vue
@@ -14,7 +14,19 @@
                 <c-user-detail-info :user="user" />
                 <!-- ボタンエリア -->
                 <m-panel class="button-area">
-                    ここにボタンを作成
+                    <c-button 
+                        v-if="user.id !== $store.getters['user/user'].id && !user.is_followed"
+                        block
+                        label="フォローする"
+                        @c-click="followButtonHandler"
+                    />
+                    <c-button
+                        v-if="user.id !== $store.getters['user/user'].id && user.is_followed"
+                        block
+                        warning
+                        label="フォロー中"
+                        @c-click="unfollowButtonHandler"
+                    />
                 </m-panel>
             </div>
             <!-- ユーザー詳細 -->
@@ -46,6 +58,17 @@ export default class PageUserDetail extends Vue {
     async loadUser() {
         const user = await this.$axios.$get(`/api/user/${this.$route.params.id}`)
         this.user = user
+    }
+
+    // ユーザーをフォローする
+    async followButtonHandler() {
+        await this.$axios.$post(`/api/user/${this.user.id}/follow`)
+        this.loadUser()
+    }
+    // ユーザーをフォローを外す
+    async unfollowButtonHandler() {
+        await this.$axios.$post(`/api/user/${this.user.id}/unfollow`)
+        this.loadUser()
     }
     mounted() {
         this.loadUser()

--- a/app/pages/user/_id/index.vue
+++ b/app/pages/user/_id/index.vue
@@ -70,6 +70,7 @@ export default class PageUserDetail extends Vue {
         await this.$axios.$post(`/api/user/${this.user.id}/unfollow`)
         this.loadUser()
     }
+    
     mounted() {
         this.loadUser()
     } 

--- a/app/types/user.d.ts
+++ b/app/types/user.d.ts
@@ -11,4 +11,5 @@ export interface ILoginUser {
     favorite_music_age: number | null
     favorite_artist: string | null
     comment: string | null
+    is_followed: boolean
 }


### PR DESCRIPTION
- typeのILoginUserにis_followedを追加。APIリクエストにより返ってくるJSONにis_followedが含まれるようにしており、Vuexのストアにユーザーリストが保存されることで、後からでそのユーザーをログイン中ユーザーがすでにフォローしているか否か判断できる。

- ユーザーをフォロー・アンフォローするボタンを曲一覧の投稿者情報・ユーザー詳細画面に追加 。
Vuexのストアから取得したis_followedの真偽値によりフォローボタン・アンフォローボタンの表示を切り替える。