### PR TITLE
曲検索機能（並び替えおよび絞り込みも含む）の作成#20

### DIFF
--- a/app/components/song/CSongEdit.vue
+++ b/app/components/song/CSongEdit.vue
@@ -49,11 +49,11 @@ export default class CSongEdit extends Vue {
     errors: Array<ApplicationError> = []
     showModal: number = 1
     musicAgeItems = [
-        { label: '1970年代', value: '1970' },
-        { label: '1980年代', value: '1980' },
-        { label: '1990年代', value: '1990' },
-        { label: '2000年代', value: '2000' },
-        { label: '2010年代', value: '2010' }
+        { label: '1970年代', value: 1970 },
+        { label: '1980年代', value: 1980 },
+        { label: '1990年代', value: 1990 },
+        { label: '2000年代', value: 2000 },
+        { label: '2010年代', value: 2010 }
     ]
     // 次へボタンが押された
     async nextHandler() {

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -5,6 +5,7 @@
                 <img v-if="song.image_url" :src="song.image_url" />
                 <img v-else src="/img/song-icon.jpeg" />
             </div>
+            {{ song.bookmarking_users.length }}
             <table class="c-song-list-item-data table no-border">
                 <tbody>
                     <tr>

--- a/app/components/song/CSongSearch.vue
+++ b/app/components/song/CSongSearch.vue
@@ -1,17 +1,83 @@
 <template>
-    <m-panel class="c-song-search">
-        <p>TODO検索フィルタ作成</p>
-        <c-button small primary label="新規追加" @c-click="addSongHandler" />
+    <m-panel v-if="!$store.getters['user/isGuest']" class="c-song-search">
+        <m-column center>
+            <div class="sort-order">
+                <c-sort-button
+                    label="追加日"
+                    :asc.sync="filter.sort.createdAtAsc"
+                    :info="filter.sort.active === 'createdAtAsc'"
+                    @cs-click="filter.sort.active = 'createdAtAsc'"
+                />
+                <c-sort-button
+                    label="更新日"
+                    :asc.sync="filter.sort.updatedAtAsc"
+                    :info="filter.sort.active === 'updatedAtAsc'"
+                    @cs-click="filter.sort.active = 'updatedAtAsc'"
+                />
+                <c-sort-button
+                    label="お気に入り数順"
+                    :asc.sync="filter.sort.bookmarkingUsersAsc"
+                    :info="filter.sort.active === 'bookmarkingUsersAsc'"
+                    @cs-click="filter.sort.active = 'bookmarkingUsersAsc'"
+                />
+            </div>
+            <div class="text-search">
+                <c-dropdown :items="musicAgeItems" :model.sync="filter.music_age" data-label="label" data-value="value" />
+                <c-text-input placeholder="検索キーワードを入力" :model.sync="filter.text" />
+            </div>
+        </m-column>
+        <div class="song-type">
+            <c-checkbox text="映像あり" :checked.sync="filter.status.hasVideo" />
+            <c-checkbox text="画像あり" :checked.sync="filter.status.hasImage" />
+            <c-checkbox text="曲紹介あり" :checked.sync="filter.status.hasDescription" />
+            <c-checkbox text="お気に入り済み" :checked.sync="filter.status.is_bookmarked" />
+            <c-button small warning label="新規追加" @c-click="addSongHandler" style="margin-left: 30%" />
+        </div>
     </m-panel>
 </template>
 
 <script lang="ts">
-import { Component, Vue, Emit } from 'vue-property-decorator'
+import { Component, Vue, Emit, PropSync, Watch } from 'vue-property-decorator'
+import { ISongFilter } from '~/types/filter'
+
 @Component({})
 export default class CSongSearch extends Vue {
+    @PropSync('filter') filterSync!: ISongFilter
+
     @Emit('add-handler')
     addSongHandler() {}
+
+    detailSearchVisible: boolean = false
+    toggleDetailSearch() {
+        this.detailSearchVisible = !this.detailSearchVisible
+    }
+
+    musicAgeItems = [
+        { label: '全ての年代', value: 0 },
+        { label: '1970年代', value: 1970  },
+        { label: '1980年代', value: 1980 },
+        { label: '1990年代', value: 1990 },
+        { label: '2000年代', value: 2000 },
+        { label: '2010年代', value: 2010 }
+    ]
+
+    @Watch('filterSync', { deep: true })
+    filterChanged() {
+        this.$emit('save-filter', null)
+    }
 }
 </script>
 
-<style lang="stylus"></style>
+<style lang="stylus">
+.c-song-search
+    .sort-order
+        flex: 0 1 auto !important
+    .text-search
+        flex: 0 0 40% !important
+        display: flex
+        .c-dropdown
+            flex: 0 0 30%
+            margin-right: 8px
+        .c-text-input
+            flex: 1 1 auto
+</style>

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -24,6 +24,10 @@
                         <td>曲紹介</td>
                         <td>{{ song.description }}</td>
                     </tr>
+                    <tr v-if="song.bookmarking_users">
+                        <td>お気に入り登録者数</td>
+                        <td>{{ song.bookmarking_users.length }}人</td>
+                    </tr>
                     <tr>
                         <td>投稿日時</td>
                         <td>{{ song.created_at }}</td>

--- a/app/components/ui/CCheckbox.vue
+++ b/app/components/ui/CCheckbox.vue
@@ -1,0 +1,61 @@
+<template>
+    <label class="c-checkbox" :class="{ disabled: disabled }">
+        <input v-model="syncChecked" type="checkbox" class="c-checkbox-input" :disabled="disabled" @change="checkedHandler" />
+        <span class="c-checkbox-parts">{{ text }}</span>
+    </label>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, PropSync, Emit } from 'vue-property-decorator'
+@Component({})
+export default class CCheckbox extends Vue {
+    @Prop({ default: '' }) text!: String
+    @PropSync('checked', { default: false }) syncChecked!: boolean
+    @Prop({ type: Boolean, default: false }) disabled!: boolean
+    @Emit('c-change')
+    private checkedHandler() {}
+}
+</script>
+<style lang="stylus">
+.c-checkbox
+  cursor: pointer
+  &-input
+    display: none;
+    &:checked + .c-checkbox-parts::after
+      content ""
+      display block
+      position absolute
+      top: 2px
+      left: 6px
+      width: 6px
+      height: 10px
+      transform rotate(45deg)
+      border-bottom 3px solid rgba(15, 59, 138, 0.54)
+      border-right 3px solid rgba(15, 59, 138, 0.54)
+      box-sizing: border-box
+    &:disabled
+      border-bottom 3px solid rgba(15, 59, 138, 0.14)
+      border-right 3px solid rgba(15, 59, 138, 0.14)
+      background-color: #eee
+  &-parts
+    padding-left 24px
+    position relative
+    &:before
+      content ""
+      display block
+      position absolute
+      top -1px
+      left 0
+      width 18px
+      height 18px
+      border 3px solid rgba(15, 59, 138, 0.54)
+      border-radius 3px
+      box-sizing: border-box
+      background-color: #fff
+  &.disabled
+    color: #999
+    .c-checkbox-input
+      opacity: 0.5
+    .c-checkbox-parts
+      &:before
+        opacity: 0.5
+</style>

--- a/app/components/ui/CSelectList.vue
+++ b/app/components/ui/CSelectList.vue
@@ -1,0 +1,120 @@
+<template>
+    <div class="c-select-list" :class="{ multiple: multiple }">
+        <ul :style="{ height: height }">
+            <li v-for="(data, index) in items" :key="index" :class="getClass(data)" @click="selectItem(data)">
+                <span v-for="(label, index2) in dataLabel.split(',')" :key="index2">
+                    {{ data[label] }}
+                </span>
+            </li>
+        </ul>
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, PropSync } from 'vue-property-decorator'
+@Component
+export default class CSelectList extends Vue {
+    // 無効状態か否か
+    @Prop(Boolean) disabled?: boolean
+    // 複数選択
+    @Prop(Boolean) multiple?: boolean
+    // 高さ
+    @Prop({ type: String, default: '100px' }) height?: string
+    // モデル
+    @PropSync('model', { default: undefined }) syncModel!: any
+    // データソース
+    @Prop({ type: Array, default: null }) items?: Array<any>
+    // ラベルキー
+    @Prop({ type: String, default: 'label' }) dataLabel!: string
+    // 値キー
+    @Prop({ type: String, default: null }) dataValue!: string
+    private serialize(data) {
+        return JSON.stringify(data)
+    }
+    // スタイル
+    private getClass(data: any) {
+        if (this.syncModel && Array.isArray(this.syncModel)) {
+            const index = this.syncModel.findIndex((it) => this.serialize(it) === this.serialize(data))
+            return {
+                selected: index >= 0
+            }
+        }
+        return {
+            selected: false
+        }
+    }
+    // 選択
+    private selectItem(data: any) {
+        // 無効の場合は反応させない
+        if (this.disabled) {
+            return
+        }
+        if (!this.multiple) {
+            const index = this.syncModel.findIndex((it) => this.serialize(it) === this.serialize(data))
+            if (index >= 0) {
+                this.syncModel.splice(index, 1)
+            } else {
+                this.syncModel.splice(0, this.syncModel.length)
+                this.syncModel.push(this.dataValue ? data[this.dataValue] : data)
+            }
+        } else if (Array.isArray(this.syncModel)) {
+            // すでに選択されている場合は解除
+            const index = this.syncModel.findIndex((it) => this.serialize(it) === this.serialize(data))
+            if (index >= 0) {
+                this.syncModel.splice(index, 1)
+            } else {
+                this.syncModel.push(this.dataValue ? data[this.dataValue] : data)
+            }
+        }
+        // 変更イベント発火
+        this.$emit('c-change', this.syncModel)
+    }
+}
+</script>
+<style lang="stylus">
+.c-select-list
+    ul
+        margin: 0
+        padding: 0
+        list-style: none
+        width: calc(100% - 18px)
+        font-size: 13px
+        padding: 6px 8px
+        border: 1px solid #ccc
+        border-radius: 4px
+        background-color: #fff
+        overflow-y: scroll
+        &:disabled
+            background-color: #ddd
+        li
+            cursor: pointer
+            &.selected
+                background-color: $dark-bg-color
+            > span
+                padding-left: 24px
+                position: relative
+                &:before
+                    content: ''
+                    display: block
+                    position: absolute
+                    top: -1px
+                    left: 0
+                    width: 18px
+                    height: 18px
+                    border: 3px solid rgba(15, 59, 138, 0.54)
+                    border-radius: 3px
+                    box-sizing: border-box
+                    background-color: #fff
+            &.selected span
+                &:after
+                    content: ''
+                    display: block
+                    position: absolute
+                    top: 2px
+                    left: 6px
+                    width: 6px
+                    height: 10px
+                    transform: rotate(45deg)
+                    border-bottom: 3px solid rgba(15, 59, 138, 0.54)
+                    border-right: 3px solid rgba(15, 59, 138, 0.54)
+                    box-sizing: border-box
+</style>

--- a/app/components/ui/CSortButton.vue
+++ b/app/components/ui/CSortButton.vue
@@ -1,0 +1,30 @@
+<template>
+    <c-button small class="c-sort-button" :class="getClass" :disabled="disabled" :label="label" @c-click="buttonHandler">
+        <span v-if="ascSync" class="asc">▲</span>
+        <span v-else class="desc">▼</span>
+    </c-button>
+</template>
+<script lang="ts">
+import { Component, PropSync } from 'vue-property-decorator'
+import CButton from '~/components/ui/CButton.vue'
+@Component
+export default class CSortButton extends CButton {
+    @PropSync('asc', { default: true }) ascSync!: boolean
+    private buttonHandler() {
+        if (this.ascSync) {
+            this.ascSync = false
+        } else {
+            this.ascSync = true
+        }
+        this.$emit('cs-click')
+    }
+}
+</script>
+<style lang="stylus">
+.c-sort-button
+    position: relative
+    border-radius: 4px
+    .asc, .desc
+        font-size: 80%
+        padding-left: 8px
+</style>

--- a/app/plugins/mixins.ts
+++ b/app/plugins/mixins.ts
@@ -15,6 +15,9 @@ import CLabeledItem from '~/components/ui/CLabeledItem.vue'
 import CDropdown from '~/components/ui/CDropdown.vue'
 import CMessage from '~/components/ui/CMessage.vue'
 import CError from '~/components/ui/CError.vue'
+import CSortButton from '~/components/ui/CSortButton.vue'
+import CCheckbox from '~/components/ui/CCheckbox.vue'
+import CSelectList from '~/components/ui/CSelectList.vue'
 
 Vue.mixin({
     components: {
@@ -32,7 +35,10 @@ Vue.mixin({
         CLabeledItem,
         CDropdown,
         CMessage,
-        CError
+        CError,
+        CSortButton,
+        CCheckbox,
+        CSelectList
     }
 })
 

--- a/app/store/song.ts
+++ b/app/store/song.ts
@@ -1,21 +1,45 @@
 import { GetterTree, ActionTree, MutationTree } from 'vuex'
 import moment from 'moment'
 import { ISong } from '~/types/song'
+import { ISongFilter} from '~/types/filter'
 export interface State {
     list: Array<ISong>
+    filter: ISongFilter
 }
 export interface RootState {}
 export const state = (): State => ({
-    list: []
+    list: [],
+    filter: {
+        text: '',
+        status: {
+            hasVideo: false,
+            hasImage:false,
+            hasDescription: false,
+            is_bookmarked: false
+        },
+        music_age: 0,
+        sort: {
+            active: 'createdAtAsc',
+            createdAtAsc: false,
+            updatedAtAsc: false,
+            bookmarkingUsersAsc: false
+        },
+    }
 })
 export const mutations: MutationTree<State> = {
     setList(state, list: Array<ISong>) {
         state.list = list
     },
+    setFilter(state, filter: ISongFilter) {
+        state.filter = filter
+    },
 }
 export const actions: ActionTree<State, RootState> = {
     setList(context, list: Array<ISong>) {
         context.commit('setList', list)
+    },
+    setFilter(context, filter: ISongFilter) {
+        context.commit('setFilter', filter)
     },
     async sync(context) {
         // 差し替え用リストを定義
@@ -45,5 +69,72 @@ export const getters: GetterTree<State, RootState> = {
     },
     findId: (state) => (id: number) => {
         return state.list.find((it) => it.id === id)
+    },
+    // 検索フィルタ取得
+    filter(state): ISongFilter {
+        return state.filter
+    },
+    // 検索
+    filterList: (state, _getters, _rootState, rootGetters) => (filter: ISongFilter) => {
+        const models = state.list
+            // テキストフィルタ
+            .filter((it) => {
+                if (filter.text.length > 0) {
+                    return (
+                        it.title.includes(filter.text) ||
+                        (it.artist_name && it.artist_name.includes(filter.text))
+                    )
+                }
+                return true
+            })
+            // 曲状態フィルタ
+            .filter((it) => {
+                // // 全ての年代が選択されている時
+                if (filter.music_age === 0) {
+                    return true
+                }
+                if (filter.music_age === it.music_age) {
+                // いずれかの年代を選択されている時
+                    return true
+                }
+                return false
+            })
+            .filter((it) => {
+                // 「映像あり」のチェックが外れると、映像がない曲を除外
+                if (filter.status.hasVideo && !it.video_url) {
+                    return false
+                }
+                // 「画像あり」のチェックが外れると、画像がない曲を除外
+                if (filter.status.hasImage && !it.image_url) {
+                    return false
+                }
+                // 「曲紹介あり」のチェックが外れると、曲紹介がない曲を除外
+                if (filter.status.hasDescription && !it.description) {
+                    return false
+                }
+                // 「曲紹介あり」のチェックが外れると、お気に入りに登録していない曲を除外
+                if (filter.status.is_bookmarked && !it.is_bookmarked) {
+                    return false
+                }
+                return true
+            })
+        models.sort((a: ISong, b: ISong) => {
+            // 対象のフィルタ 昇順/降順 を取得
+            const asc = filter.sort[filter.sort.active]
+            // 追加日
+            if (filter.sort.active === 'createdAtAsc' && a.created_at && b.created_at) {
+                return (moment(a.created_at) < moment(b.created_at) ? 1 : -1) * (asc ? -1 : 1)
+            }
+            // 更新日
+            if (filter.sort.active === 'updatedAtAsc' && a.updated_at && b.updated_at) {
+                return (moment(a.updated_at) < moment(b.updated_at) ? 1 : -1) * (asc ? -1 : 1)
+            }
+            // お気に入り数順
+            if (filter.sort.active === 'bookmarkingUsersAsc') {
+                return (a.bookmarking_users.length! < b.bookmarking_users.length! ? 1 : -1) * (asc ? -1 : 1)
+            }
+            return 0
+        })
+        return models
     },
 }

--- a/app/types/filter.d.ts
+++ b/app/types/filter.d.ts
@@ -1,0 +1,32 @@
+import { ISong } from './song'
+
+export interface ISongFilter {
+    // 自由テキストフィルタ
+    text: string
+    // 曲の年代フィルタ
+    music_age: number
+    // 曲状態フィルタ
+    status: ISongFilterStatus
+    // 並び順
+    sort: ISongFilterSort
+}
+export interface ISongFilterStatus {
+    // 映像ありか
+    hasVideo: boolean
+    // 曲の画像ありか
+    hasImage:boolean
+    // 曲紹介ありか
+    hasDescription: false
+    // ログイン中ユーザーがお気に入りに登録済みの曲か
+    is_bookmarked: boolean
+}
+export interface ISongFilterSort {
+    // 有効な並び順
+    active: string
+    // 追加日
+    createdAtAsc: boolean
+    // 更新日
+    updatedAtAsc: boolean
+    // お気に入りされた数が多い順
+    bookmarkingUsersAsc: boolean
+}

--- a/app/types/initializer.ts
+++ b/app/types/initializer.ts
@@ -12,6 +12,7 @@ export function newSong(): ISong {
         created_at: '',
         updated_at: '',
         deleted_at: null,
-        is_bookmarked: false
+        is_bookmarked: false,
+        bookmarking_users: []
     }
 }

--- a/app/types/song.d.ts
+++ b/app/types/song.d.ts
@@ -1,3 +1,5 @@
+import { ILoginUser } from '~/types/user'
+
 export interface ISong {
     id: number | null
     user_id: number | null
@@ -11,4 +13,5 @@ export interface ISong {
     updated_at: string
     deleted_at: string | null
     is_bookmarked: boolean
+    bookmarking_users: Array<any>
 }


### PR DESCRIPTION
曲検索機能の作成。
以下のテキストボックス・絞り込み・並び替えで曲一覧の表示を切り替える。
曲へのお気に入り数を取得するため、songにAPIリクエストでJSONで取得したbookmarking_usersを追加。
検索フィルタの状態が変わるたびに、状態をストアに保存。

- テキストボックス→タイトル・アーティスト名の部分一致

- 曲の年代による絞り込み

- 映像あり・画像あり・曲紹介あり・お気に入り済みで、チェックが入ったもので絞り込み

- 追加日順・更新日順・お気に入り数順で並び替え