### PR TITLE
vue-youtubeのインストールおよび動画表示エリアの作成 issue#39

### DIFF
--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -85,8 +85,7 @@ export default class CSongDetail extends Vue {
 
     @Watch('selectedTab')
     fixed() {
-        console.log(this.selectedTab)
-        if (this.selectedTab === 2 && this.song.comments.length >3) {
+        if ((this.selectedTab === 2 && this.song.comments.length >2) || (this.selectedTab === 0 && this.song.video_url !== null)) {
             this.$emit('position-fixed', false)
         } else {
             this.$emit('position-fixed', true)

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -41,10 +41,10 @@
         </m-column>
     </li>
 </template>
-
 <script lang="ts">
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 import { ISong } from '~/types/song'
+
 @Component({})
 export default class CSongListItem extends Vue {
     @Prop(Object) song!: ISong

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -43,7 +43,7 @@
                 </tbody>
             </table>
             <div v-if="song.video_url">
-                動画をここに表示TODO
+                <youtube :video-id="song.video_url" width="100%"></youtube>
             </div>
             <c-button
                 v-if="song.user_id === $store.getters['user/user'].id"

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -40,7 +40,7 @@
 
 <script lang="ts">
 import _ from 'lodash'
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Vue, Watch } from 'vue-property-decorator'
 import CSongListItem from '~/components/song/CSongListItem.vue'
 import CSongDetail from '~/components/song/CSongDetail.vue'
 import CSongEdit from '~/components/song/CSongEdit.vue'
@@ -68,6 +68,8 @@ export default class PageSongIndex extends Vue {
     }
     songModalModel: ISong = newSong()
     songModalVisible: boolean = false
+
+    hasVideo: boolean = false
 
     // 検索フィルタ
     filter: ISongFilter = {
@@ -169,7 +171,15 @@ export default class PageSongIndex extends Vue {
         } else {
             this.fixed = false
         }
-    }   
+    }
+    @Watch('selectedSong') 
+    changeSelect() {
+        if (this.selectedSong && this.selectedSong.video_url !== null) {
+            this.fixed = false
+        } else {
+            this.fixed = true
+        }
+    }
 }
 </script>
 

--- a/app/plugins/vue-youtube.ts
+++ b/app/plugins/vue-youtube.ts
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+// import * as Vue
+// import * as VueYoutube from 'vue-youtube'
+import VueYoutube from 'vue-youtube'
+
+Vue.use(VueYoutube)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,7 +36,8 @@ const config: Configuration = {
      */
     plugins: [
         '~/plugins/mixins',
-        '~/plugins/axios'
+        '~/plugins/axios',
+        '~/plugins/vue-youtube'
     ],
     router: {
         middleware: ['auth']

--- a/package-lock.json
+++ b/package-lock.json
@@ -4939,6 +4939,11 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "get-youtube-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-youtube-id/-/get-youtube-id-1.0.1.tgz",
+      "integrity": "sha512-5yidLzoLXbtw82a/Wb7LrajkGn29BM6JuLWeHyNfzOGp1weGyW4+7eMz6cP23+etqj27VlOFtq8fFFDMLq/FXQ=="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -8667,6 +8672,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loadash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
@@ -10850,6 +10860,11 @@
         }
       }
     },
+    "sister": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
+    },
     "sisteransi": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
@@ -12265,6 +12280,15 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "vue-youtube": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vue-youtube/-/vue-youtube-1.4.0.tgz",
+      "integrity": "sha512-PCyfGAouSt6rTX0GLUzpdX2XC52zYf7a9mUhdp53jeDlPoU40hpsvyV3Zg2+947pvbv27ORcmtzm2fqO08kh9Q==",
+      "requires": {
+        "get-youtube-id": "^1.0.0",
+        "youtube-player": "^5.4.0"
+      }
+    },
     "vue2-editor": {
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/vue2-editor/-/vue2-editor-2.10.2.tgz",
@@ -12687,6 +12711,16 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    },
+    "youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "requires": {
+        "debug": "^2.6.6",
+        "load-script": "^1.0.0",
+        "sister": "^3.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5",
     "vue-property-decorator": "^8.3.0",
+    "vue-youtube": "^1.4.0",
     "vue2-editor": "^2.10.2",
     "vuex-class": "^0.3.2",
     "vuex-module-decorator": "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,7 +4032,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -5554,6 +5554,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+get-youtube-id@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-youtube-id/-/get-youtube-id-1.0.1.tgz#adb6f475e292d98f98ed5bfb530887656193e157"
+  integrity sha512-5yidLzoLXbtw82a/Wb7LrajkGn29BM6JuLWeHyNfzOGp1weGyW4+7eMz6cP23+etqj27VlOFtq8fFFDMLq/FXQ==
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -7406,6 +7411,11 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
 
 loadash@^1.0.0:
   version "1.0.0"
@@ -10590,6 +10600,11 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sister@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sister/-/sister-3.0.2.tgz#bb3e39f07b1f75bbe1945f29a27ff1e5a2f26be4"
+  integrity sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==
+
 sisteransi@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.4.tgz#386713f1ef688c7c0304dc4c0632898941cad2e3"
@@ -12078,6 +12093,14 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue-youtube@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/vue-youtube/-/vue-youtube-1.4.0.tgz#34b74a967783d3c64596d886efef5966032f9428"
+  integrity sha512-PCyfGAouSt6rTX0GLUzpdX2XC52zYf7a9mUhdp53jeDlPoU40hpsvyV3Zg2+947pvbv27ORcmtzm2fqO08kh9Q==
+  dependencies:
+    get-youtube-id "^1.0.0"
+    youtube-player "^5.4.0"
+
 vue2-editor@^2.10.2:
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/vue2-editor/-/vue2-editor-2.10.2.tgz#57dd2275d66a407c8078330951a9b601840f033f"
@@ -12601,3 +12624,12 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+youtube-player@^5.4.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
+  integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
+  dependencies:
+    debug "^2.6.6"
+    load-script "^1.0.0"
+    sister "^3.0.0"


### PR DESCRIPTION
曲詳細エリアに曲の動画（YouTube）を表示するように。

- songのJSONに含まれるvideo_urlを使用。

- vue-youtubeをインストール。

- 曲選択時に、動画がある曲に関しては、曲詳細エリアの固定を解除。