### PR TITLE
マイプロフィール画面にて、アイコンの設定（アップロード）機能の作成#41

### DIFF
--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -4,7 +4,6 @@
             <div class="c-song-list-item-photo">
                 <img v-if="song.image_url" :src="song.image_url" />
                 <img v-else src="/img/song-icon.jpeg" />
-                <c-button v-if="song.user_id === $store.getters['user/user'].id" tiny @c-click="selectFile">ファイル選択</c-button>
             </div>
             <table class="c-song-list-item-data table no-border">
                 <tbody>
@@ -52,14 +51,6 @@ export default class CSongListItem extends Vue {
 
     @Emit('c-select')
     selectSong() {}
-
-    selectFile() {
-        const input: HTMLInputElement | null = document.querySelector(`#${this.song.id}-input`)
-        if (input) {
-            input.click()
-        }
-    }
-
 }
 </script>
 

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -4,6 +4,7 @@
             <div class="c-song-list-item-photo">
                 <img v-if="song.image_url" :src="song.image_url" />
                 <img v-else src="/img/song-icon.jpeg" />
+                <c-button v-if="song.user_id === $store.getters['user/user'].id" tiny @c-click="selectFile">ファイル選択</c-button>
             </div>
             <table class="c-song-list-item-data table no-border">
                 <tbody>
@@ -51,6 +52,14 @@ export default class CSongListItem extends Vue {
 
     @Emit('c-select')
     selectSong() {}
+
+    selectFile() {
+        const input: HTMLInputElement | null = document.querySelector(`#${this.song.id}-input`)
+        if (input) {
+            input.click()
+        }
+    }
+
 }
 </script>
 

--- a/app/plugins/vue-youtube.ts
+++ b/app/plugins/vue-youtube.ts
@@ -1,6 +1,4 @@
 import Vue from 'vue'
-// import * as Vue
-// import * as VueYoutube from 'vue-youtube'
 import VueYoutube from 'vue-youtube'
 
 Vue.use(VueYoutube)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,7 +53,7 @@ const config: Configuration = {
         '@nuxtjs/axios',
         '@nuxtjs/proxy',
         '@nuxtjs/style-resources',
-        ['cookie-universal-nuxt', { alias: 'cookies' }],
+        ['cookie-universal-nuxt', { alias: 'cookies' }]
     ],
     axios: {
         prefix: '/api'


### PR DESCRIPTION
- アイコン設定エリアとプロフィール設定エリアとでカラムを２つに分けた。

- 「アイコン変更」ボタンを押すと、inputタグをquerySelectorで取得し、画像ダイアログファイル選択画面が開く。

- ファイルを選択するとaxiosでAPIのpostリクエストが投げられる。

- アップロード後はユーザー情報をAPIで取得し、ストアのユーザー情報を更新する。

- アイコンの変更成功のメッセージを表示する。