### PR TITLE
ユーザー登録・ログイン後の画面遷移先を曲一覧画面に・トップ画面のレイアウト修正

### DIFF
--- a/app/pages/dashboard/index.vue
+++ b/app/pages/dashboard/index.vue
@@ -2,7 +2,7 @@
     <m-page class="page-dashboard">
         <div>
             <p>ダッシュボード</p>
-            <pre>{{ $store.getters['user/user'] }}</pre>
+            <pre>{{ $store.getters['user/user'].name }}</pre>
         </div>
     </m-page>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,12 +1,15 @@
 <template>
-    <div class="page-index">
-        <div>
-            <h1 class="title">Your Songs</h1>
-            <h2 class="subtitle">Welcome</h2>
-            <nuxt-link to="/user/signin">ログインページへ</nuxt-link>
-            <nuxt-link to="/signup">ユーザー登録ページへ</nuxt-link>
-        </div>
-    </div>
+    <m-page class="page-index" title="YourSongs">
+        <h1 class="subtitle">Welcome</h1>
+        <ul>
+            <li>
+                <nuxt-link to="/user/signin">ログインページへ</nuxt-link>
+            </li>
+            <li>
+                <nuxt-link to="/signup">ユーザー登録ページへ</nuxt-link>
+            </li>
+            </ul>
+    </m-page>
 </template>
 
 <script lang="ts">

--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -61,7 +61,7 @@ export default class PageSignup extends Vue {
                     path: '/',
                 })
                 // ダッシュボードに遷移
-                this.$router.replace('/dashboard')
+                this.$router.replace('/song')
             }
         } catch (e) {
             this.errors.push(e)

--- a/app/pages/user/signin.vue
+++ b/app/pages/user/signin.vue
@@ -53,7 +53,7 @@ export default class PageSignin extends Vue {
                     path: '/',
                 })
                 // ダッシュボードに遷移
-                this.$router.replace('/dashboard')
+                this.$router.replace('/song')
             }
         } catch (e) {
             this.errors.push(e)


### PR DESCRIPTION
- ユーザー登録・ログイン後の画面遷移先を曲一覧画面（/song）に

- トップ画面のレイアウトが崩れていたため修正
