### PR TITLE
曲の画像アップロード機能の作成 #50

### DIFF
--- a/app/components/song/CSongDetail.vue
+++ b/app/components/song/CSongDetail.vue
@@ -16,6 +16,7 @@
                 @delete-handler="deleteButtonHandler"
                 @bookmark-handler="bookmarkButtonHandler"
                 @remove-bookmark-handler="removeBookmarkButtonHandler"
+                @upload-handler="uploadButtonHandler"
             />
             <c-song-detail-contributor
                 v-if="selectedTab === 1"
@@ -77,6 +78,9 @@ export default class CSongDetail extends Vue {
 
     @Emit('c-song-comment-delete-finished')
     songCommentDeleteFinishedHandler() {}
+
+    @Emit('c-song-icon-upload')
+    uploadButtonHandler() {}
 
     @Watch('song')
     songChanged() {

--- a/app/components/song/CSongIcon.vue
+++ b/app/components/song/CSongIcon.vue
@@ -1,0 +1,77 @@
+<template>
+    <m-modal
+        :visible.sync="modalVisible"
+        width="500px"
+        height="80vh"
+        :title="syncModel.image_url === null ? syncModel.title + '画像を設定' : syncModel.title + 'の画像を変更'"
+        :is-only-close="true"
+        @close="modalVisible = false"
+    >
+        <c-error :errors.sync="errors" />
+        <div class="song-photo">
+                <img v-if="syncModel.image_url" class="song__icon" :src="syncModel.image_url" />
+                <img v-else class="song__icon" src="/img/song-icon.jpeg">
+                <div>
+                    <input
+                        class="avator__input"
+                        type="file"
+                        id="avator-input"
+                        accept="image/png,image/jpeg,image/gif"
+                        v-on:change="uploadIcon"
+                        style="display: none"
+                    />
+                    <c-button class="avator__button" label="画像を選択する" small success @c-click="selectAvator" />
+                </div>
+            </div>
+    </m-modal>
+</template>
+
+<script lang="ts">
+import { Component, Vue, PropSync, Watch, Emit } from 'vue-property-decorator'
+import { ISong } from '~/types/song'
+import { ApplicationError, BadRequest } from '~/types/error'
+@Component
+export default class CSongIcon extends Vue {
+    @PropSync('visible') modalVisible!: boolean
+    @PropSync('model') syncModel!: ISong
+    errors: Array<ApplicationError> = []
+    iconErrors: Array<ApplicationError> = []
+    iconUrl: string = ''
+    
+    selectAvator() {
+      const input: HTMLInputElement | null = document.querySelector('#avator-input');
+      if (input) {
+        input.click()
+      }
+    }
+    
+    async uploadIcon(e: any) {
+        this.iconErrors = []
+        e.preventDefault()
+        try {
+            const files = e.target.files ? e.target.files : e.dataTransfer.files
+            const file = files[0]
+            const params = new FormData()
+            params.append('file', file)
+            if (e.target.files.length === 0) {
+                return null
+            }
+            const avatorfile = e.target.files[0];
+            let response: any = null
+            response = await this.$axios.$post(`/api/song/${this.syncModel.id}/image`, params)
+            this.modalVisible = false
+            this.$emit('c-song-icon-uploaded')
+        } catch (e) {
+            this.iconErrors.push(e)
+        }
+    }
+}
+</script>
+<style lang="stylus">
+.song-photo
+    text-align center
+    .song__icon
+        height: 300px
+        width: 300px
+        margin-bottom 5px
+</style>

--- a/app/components/song/CSongListItem.vue
+++ b/app/components/song/CSongListItem.vue
@@ -2,8 +2,8 @@
     <li v-if="song" class="c-song-list-item" @click="selectSong">
         <m-column center>
             <div class="c-song-list-item-photo">
-                <img v-if="song.image_url" :src="song.image_url" />
-                <img v-else src="/img/song-icon.jpeg" />
+                <img v-if="song.image_url" class="song__icon" :src="song.image_url" />
+                <img v-else class="song__icon" src="/img/song-icon.jpeg">
             </div>
             <table class="c-song-list-item-data table no-border">
                 <tbody>
@@ -43,6 +43,7 @@
 </template>
 <script lang="ts">
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
+import { ApplicationError, BadRequest } from '~/types/error'
 import { ISong } from '~/types/song'
 
 @Component({})

--- a/app/components/song/detail/CSongDetailInfo.vue
+++ b/app/components/song/detail/CSongDetailInfo.vue
@@ -48,6 +48,14 @@
             <c-button
                 v-if="song.user_id === $store.getters['user/user'].id"
                 small
+                success
+                block
+                label="画像を変更する"
+                @c-click="uploadButtonHandler"
+            />
+            <c-button
+                v-if="song.user_id === $store.getters['user/user'].id"
+                small
                 block
                 label="編集"
                 @c-click="editButtonHandler"
@@ -80,6 +88,7 @@
 </template>
 <script lang="ts">
 import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
+import { ApplicationError, BadRequest } from '~/types/error'
 import { ISong } from '~/types/song'
 import { newSong } from '~/types/initializer'
 import CSongEdit from '~/components/song/CSongEdit.vue'
@@ -104,6 +113,9 @@ export default class CSongDetailInfo extends Vue {
     
     @Emit('remove-bookmark-handler')
     removeBookmarkButtonHandler() {}
+
+    @Emit('upload-handler')
+    uploadButtonHandler() {}
 }
 </script>
 <style lang="stylus">

--- a/app/pages/song/index.vue
+++ b/app/pages/song/index.vue
@@ -1,5 +1,6 @@
 <template>
     <m-page class="page-song-index">
+        <c-message class="iconChangedMessage" v-if="iconUploaded" success>曲の画像を変更しました</c-message>
         <c-song-search
             :filter.sync="filter"
             @add-handler="addSongHandler"
@@ -25,6 +26,7 @@
                 @c-song-detail-delete="deleteButtonHandler"
                 @c-song-detail-bookmark="bookmarkButtonHandler"
                 @c-song-detail-remove-bookmark="removeBookmarkButtonHandler"
+                @c-song-icon-upload="uploadButtonHandler"
                 @c-song-comment-edit-finished="songCommentEditFinished"
                 @c-song-comment-delete-finished="songCommentDeleteFinished"
                 @position-fixed="positionFixed"
@@ -35,6 +37,7 @@
             </div>
         </m-column>
         <c-song-edit :visible.sync="songModalVisible" :model.sync="songModalModel" @c-song-edit-finished="songEditFinished" />
+        <c-song-icon :visible.sync="iconModalVisible" :model.sync="iconModalModel" @c-song-icon-uploaded="songIconUploaded" />
     </m-page>
 </template>
 
@@ -45,6 +48,7 @@ import CSongListItem from '~/components/song/CSongListItem.vue'
 import CSongDetail from '~/components/song/CSongDetail.vue'
 import CSongEdit from '~/components/song/CSongEdit.vue'
 import CSongSearch from '~/components/song/CSongSearch.vue'
+import CSongIcon from '~/components/song/CSongIcon.vue'
 import { ISong } from '~/types/song'
 import { newSong } from '~/types/initializer'
 import { ISongFilter } from '~/types/filter'
@@ -56,7 +60,8 @@ import { ISongFilter } from '~/types/filter'
         CSongListItem,
         CSongDetail,
         CSongEdit,
-        CSongSearch
+        CSongSearch,
+        CSongIcon
     }
 })
 export default class PageSongIndex extends Vue {
@@ -68,6 +73,9 @@ export default class PageSongIndex extends Vue {
     }
     songModalModel: ISong = newSong()
     songModalVisible: boolean = false
+    iconModalModel: ISong = newSong()
+    iconModalVisible: boolean = false
+    iconUploaded: boolean = false
 
     hasVideo: boolean = false
 
@@ -149,8 +157,27 @@ export default class PageSongIndex extends Vue {
         this.songs = await this.$store.getters['song/list']
         this.selectedSong = this.$store.getters['song/find'](this.selectedSong)
     }
+
+    // 曲の画像を変更するモーダルを表示
+    async uploadButtonHandler() {
+        if (this.selectedSong) {
+            this.iconModalModel = _.cloneDeep(this.selectedSong)
+            this.iconModalVisible = true
+        }
+    }
+
+    // 曲の画像アップロード完了後
+    songIconUploaded() {
+        this.loadSongs()
+        this.iconUploaded = true
+        setTimeout(this.closeMessage, 3000);
+    }
     
-    mounted () {
+    closeMessage() {
+        this.iconUploaded = false
+    }
+
+    mounted() {
         if(this.$store.getters['user/isGuest']) {
             this.$router.replace('/user/signin')
         }
@@ -192,4 +219,9 @@ export default class PageSongIndex extends Vue {
             flex: 1 1 auto
             position: fixed
             right: 30px
+    .iconChangedMessage
+        position: fixed
+        width 92%
+        z-index 99
+        opacity 0.9
 </style>


### PR DESCRIPTION
- 曲に対して画像ファイルをアップロードし、S3にファイル・データベースにS3での画像URLを保存するようにした。

- 曲情報タブ選択時に画像を変更ボタンを設置。ボタンを押すと画像設定モーダルが表示される。

- 画像アップロード後は、モーダルが閉じ、曲一覧画面にて曲リストを再読み込みする。

- 画像変更の成功メッセージが表示され、３秒後に消える。
